### PR TITLE
fix vite deploy bug

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -22,7 +22,8 @@
     "react-dom": "^18.2.0",
     "react-responsive-masonry": "^2.1.7",
     "react-router-dom": "^6.21.3",
-    "react-scripts": "^5.0.1"
+    "react-scripts": "^5.0.1",
+    "vite": "^4.3.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.28",


### PR DESCRIPTION
add vite to client dependencies package, since deploy to heroku get issue: remote: sh: 1: vite: not found